### PR TITLE
Preview fixes and configuration improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ build
 dist
 sitegen.egg-info
 .ropeproject
+.project
+.pydevproject
 .sass-cache
 *.pyc
 *.orig
+*~

--- a/django_markdown/static/django_markdown/markdown.js
+++ b/django_markdown/static/django_markdown/markdown.js
@@ -12,8 +12,9 @@
 // -------------------------------------------------------------------
 
 // mIu nameSpace to avoid conflict.
-miu = {
-    settings: {
+miu = (function($){
+    
+    var settings = {
         onShiftEnter:       {keepDefault:false, openWith:'\n\n'},
         markupSet: [
             {name:'First Level Heading', key:'1', placeHolder:'Your title here...', closeWith:function(markItUp) { return miu.markdownTitle(markItUp, '=') } },
@@ -39,16 +40,63 @@ miu = {
             {separator:'---------------'},
             {name:'Preview', call:'preview', className:"preview"}
         ]
-    },
+    };
     
-	markdownTitle: function(markItUp, char) {
-		heading = '';
-		n = (jQuery || django.jQuery).trim(markItUp.selection||markItUp.placeHolder).length;
-		// work around bug in python-markdown where header underlines must be at least 3 chars
-		if (n < 3) { n = 3; }
-		for(i = 0; i < n; i++) {
-			heading += char;
-		}
-		return '\n'+heading;
-	}
-}
+    function getCookie(name) {
+        var value = null;
+        
+        if (document.cookie && document.cookie != '') {
+            var cookies = document.cookie.split(';');
+            for (var i = 0; i < cookies.length; i++) {
+                var cookie = $.trim(cookies[i]);
+                // Does this cookie string begin with the name we want?
+                if (cookie.substring(0, name.length + 1) == (name + '=')) {
+                    value = decodeURIComponent(cookie.substring(name.length + 1));
+                    break;
+                }
+            }
+        }
+        
+        return value;
+    }
+    
+    /*
+     * Add "X-CSRFToken" header to every AJAX request within current domain
+     * */
+    $('html').ajaxSend(function(event, xhr, settings) {
+        var isLocal = !settings.url.match(/^https?:\/\/([^\/]+)/i);
+        
+        if(isLocal || RegExp.$1 == document.location.host){
+            xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+        }
+    })
+    
+    
+    return {
+        settings: settings,
+        
+        /*
+         * work around bug in python-markdown where header underlines must be at least 3 chars
+         * */
+    	markdownTitle: function(markItUp, char) {
+    		heading = '';
+    		n = $.trim(markItUp.selection || markItUp.placeHolder).length;
+    		if (n < 3) { n = 3; }
+    		for(i = 0; i < n; i++) {
+    			heading += char;
+    		}
+    		return '\n'+heading;
+    	},
+        
+        /*
+         * Shortcut for initializing editor
+         * */
+        init: function(textareId, extraSettings){
+            $(document).ready(function() {
+                $('#' + textareId).markItUp($.extend(settings, extraSettings));
+            });
+        }
+        
+    }
+    
+})(jQuery || django.jQuery);

--- a/django_markdown/static/django_markdown/markdown.js
+++ b/django_markdown/static/django_markdown/markdown.js
@@ -10,37 +10,37 @@
 // -------------------------------------------------------------------
 // Feel free to add more tags
 // -------------------------------------------------------------------
-mySettings = {
-	previewParserPath:	'/markitup/preview/',
-	onShiftEnter:		{keepDefault:false, openWith:'\n\n'},
-	markupSet: [
-		{name:'First Level Heading', key:'1', placeHolder:'Your title here...', closeWith:function(markItUp) { return miu.markdownTitle(markItUp, '=') } },
-		{name:'Second Level Heading', key:'2', placeHolder:'Your title here...', closeWith:function(markItUp) { return miu.markdownTitle(markItUp, '-') } },
-		{name:'Heading 3', key:'3', openWith:'### ', placeHolder:'Your title here...' },
-		{name:'Heading 4', key:'4', openWith:'#### ', placeHolder:'Your title here...' },
-		{name:'Heading 5', key:'5', openWith:'##### ', placeHolder:'Your title here...' },
-		{name:'Heading 6', key:'6', openWith:'###### ', placeHolder:'Your title here...' },
-		{separator:'---------------' },		
-		{name:'Bold', key:'B', openWith:'**', closeWith:'**'},
-		{name:'Italic', key:'I', openWith:'_', closeWith:'_'},
-		{separator:'---------------' },
-		{name:'Bulleted List', openWith:'- ' },
-		{name:'Numeric List', openWith:function(markItUp) {
-			return markItUp.line+'. ';
-		}},
-		{separator:'---------------' },
-		{name:'Picture', key:'P', replaceWith:'![[![Alternative text]!]]([![Url:!:http://]!] "[![Title]!]")'},
-		{name:'Link', key:'L', openWith:'[', closeWith:']([![Url:!:http://]!] "[![Title]!]")', placeHolder:'Your text to link here...' },
-		{separator:'---------------'},	
-		{name:'Quotes', openWith:'> '},
-		{name:'Code Block / Code', openWith:'(!(\t|!|`)!)', closeWith:'(!(`)!)'},
-		{separator:'---------------'},
-		{name:'Preview', call:'preview', className:"preview"}
-	]
-}
 
 // mIu nameSpace to avoid conflict.
 miu = {
+    settings: {
+        onShiftEnter:       {keepDefault:false, openWith:'\n\n'},
+        markupSet: [
+            {name:'First Level Heading', key:'1', placeHolder:'Your title here...', closeWith:function(markItUp) { return miu.markdownTitle(markItUp, '=') } },
+            {name:'Second Level Heading', key:'2', placeHolder:'Your title here...', closeWith:function(markItUp) { return miu.markdownTitle(markItUp, '-') } },
+            {name:'Heading 3', key:'3', openWith:'### ', placeHolder:'Your title here...' },
+            {name:'Heading 4', key:'4', openWith:'#### ', placeHolder:'Your title here...' },
+            {name:'Heading 5', key:'5', openWith:'##### ', placeHolder:'Your title here...' },
+            {name:'Heading 6', key:'6', openWith:'###### ', placeHolder:'Your title here...' },
+            {separator:'---------------' },     
+            {name:'Bold', key:'B', openWith:'**', closeWith:'**'},
+            {name:'Italic', key:'I', openWith:'_', closeWith:'_'},
+            {separator:'---------------' },
+            {name:'Bulleted List', openWith:'- ' },
+            {name:'Numeric List', openWith:function(markItUp) {
+                return markItUp.line+'. ';
+            }},
+            {separator:'---------------' },
+            {name:'Picture', key:'P', replaceWith:'![[![Alternative text]!]]([![Url:!:http://]!] "[![Title]!]")'},
+            {name:'Link', key:'L', openWith:'[', closeWith:']([![Url:!:http://]!] "[![Title]!]")', placeHolder:'Your text to link here...' },
+            {separator:'---------------'},  
+            {name:'Quotes', openWith:'> '},
+            {name:'Code Block / Code', openWith:'(!(\t|!|`)!)', closeWith:'(!(`)!)'},
+            {separator:'---------------'},
+            {name:'Preview', call:'preview', className:"preview"}
+        ]
+    },
+    
 	markdownTitle: function(markItUp, char) {
 		heading = '';
 		n = (jQuery || django.jQuery).trim(markItUp.selection||markItUp.placeHolder).length;

--- a/django_markdown/templates/django_markdown/preview.html
+++ b/django_markdown/templates/django_markdown/preview.html
@@ -4,7 +4,7 @@
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>markItUp! preview</title>
-<link rel="stylesheet" type="text/css" href="{% firstof STATIC_URL MEDIA_URL %}markdown/preview.css" />
+<link rel="stylesheet" type="text/css" href="{% firstof STATIC_URL MEDIA_URL %}django_markdown/preview.css" />
 </head>
 <body>
 {{ request.POST.data|markdown }}

--- a/django_markdown/templates/django_markdown/preview.html
+++ b/django_markdown/templates/django_markdown/preview.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" type="text/css" href="{% firstof STATIC_URL MEDIA_URL %}django_markdown/preview.css" />
 </head>
 <body>
-{{ request.POST.data|markdown }}
+{{ params.content|markdown }}
 </body>
 </html>
 

--- a/django_markdown/views.py
+++ b/django_markdown/views.py
@@ -1,5 +1,5 @@
+import logging
 from django.views.generic.simple import direct_to_template
 
-
 def preview(request):
-    return direct_to_template(request, 'django_markdown/preview.html')
+    return direct_to_template(request, 'django_markdown/preview.html', content=request.REQUEST.get('data', 'No content posted'))

--- a/django_markdown/widgets.py
+++ b/django_markdown/widgets.py
@@ -24,14 +24,7 @@ class MarkdownWidget(forms.Textarea):
         editor_settings = getattr(settings, 'MARKDOWN_EDITOR_SETTINGS', {})
         editor_settings['previewParserPath'] = reverse('django_markdown_preview')
         
-        html += ("""
-                <script type="text/javascript">
-                (function($) {
-                    $(document).ready(function() {
-                        $("#%(id)s").markItUp($.extend(miu.settings, %(settings)s));
-                    });
-                })(jQuery || django.jQuery);
-                </script>
-                """ % {'id': attrs['id'], 'settings': simplejson.dumps(editor_settings)})
+        html += '<script type="text/javascript">miu.init(\'%s\', %s)</script>' % (attrs['id'], simplejson.dumps(editor_settings))
+        
         return mark_safe(html)
 

--- a/django_markdown/widgets.py
+++ b/django_markdown/widgets.py
@@ -2,6 +2,7 @@ from django import forms
 from django.core.urlresolvers import reverse
 from django.conf import settings
 from django.utils.safestring import mark_safe
+from django.utils.simplejson import simplejson
 
 
 class MarkdownWidget(forms.Textarea):
@@ -12,21 +13,25 @@ class MarkdownWidget(forms.Textarea):
         )
         css = {
             'screen': (
-                settings.STATIC_URL + 'django_markdown/skins/%s/style.css' % getattr(settings, 'MARKDOWN_SKIN', 'markitup'),
+                settings.STATIC_URL + 'django_markdown/skins/%s/style.css' % getattr(settings, 'MARKDOWN_EDITOR_SKIN', 'markitup'),
                 settings.STATIC_URL + 'django_markdown/markdown.css',
             )
         }
 
     def render(self, name, value, attrs=None):
         html = super(MarkdownWidget, self).render(name, value, attrs)
-
-        html += ('<script type="text/javascript">'
-                '(function($) { '
-                'mySettings.previewParserPath = "%(path)s";'
-                 '$(document).ready(function() {'
-                 '  $("#%(id)s").markItUp(mySettings);'
-                 '});'
-                 '})(jQuery || django.jQuery);'
-                 '</script>' % {'id': attrs['id'], 'path': reverse('django_markdown_preview') })
+        
+        editor_settings = getattr(settings, 'MARKDOWN_EDITOR_SETTINGS', {})
+        editor_settings['previewParserPath'] = reverse('django_markdown_preview')
+        
+        html += ("""
+                <script type="text/javascript">
+                (function($) {
+                    $(document).ready(function() {
+                        $("#%(id)s").markItUp($.extend(miu.settings, %(settings)s));
+                    });
+                })(jQuery || django.jQuery);
+                </script>
+                """ % {'id': attrs['id'], 'settings': simplejson.dumps(editor_settings)})
         return mark_safe(html)
 


### PR DESCRIPTION
I added extra headers to let preview pass the CSRF check, and did some minor changes in the template.

settings.MARKDOWN_EDITOR_SETTINGS holds the extra parameters set to be passed to textarea.markItUp(). 
Also it would be convenient to pass instance-specific params as widgets.MarkdownWidget(..., editor_settings={}), maybe I'll add that later.
