### PR TITLE
Update to support Django 1.5.

### DIFF
--- a/django_markdown/templates/django_markdown/preview.html
+++ b/django_markdown/templates/django_markdown/preview.html
@@ -7,7 +7,7 @@
 <link rel="stylesheet" type="text/css" href="{% firstof STATIC_URL MEDIA_URL %}django_markdown/preview.css" />
 </head>
 <body>
-{{ params.content|markdown }}
+{{ content|markdown }}
 </body>
 </html>
 

--- a/django_markdown/urls.py
+++ b/django_markdown/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import url, patterns
+from django.conf.urls import patterns, url
 
 from django_markdown.views import preview
 

--- a/django_markdown/views.py
+++ b/django_markdown/views.py
@@ -1,7 +1,7 @@
-from django.views.generic.simple import direct_to_template
+from django.shortcuts import render
 
 
 def preview(request):
-    return direct_to_template(
+    return render(
             request, 'django_markdown/preview.html',
             content=request.REQUEST.get('data', 'No content posted'))


### PR DESCRIPTION
Change from the (removed) django.conf.urls.direct_to_template to
django.shortcuts.render.
