### PR TITLE
Side-by-side widget, custom CSS for preview

### DIFF
--- a/django_markdown/static/django_markdown/jquery.markitup.js
+++ b/django_markdown/static/django_markdown/jquery.markitup.js
@@ -125,6 +125,9 @@
 
 				// listen key events
 				$$.keydown(keyPressed).keyup(keyPressed);
+
+                // listen scroll events
+                $$.scroll(handleTextareaScroll);
 				
 				// bind an event to catch external calls
 				$$.bind("insertion", function(e, settings) {
@@ -428,6 +431,11 @@
 							iFrame.insertBefore(header);
 						}	
 						previewWindow = iFrame[iFrame.length - 1].contentWindow || frame[iFrame.length - 1];
+
+                        // listen scoll events
+                        iFrame.load(function() {
+                           iFrame.contents().scroll(handleiFrameScroll);
+                        });
 					}
 				} else if (altKey === true) {
 					if (iFrame) {
@@ -536,6 +544,36 @@
 					}
 				}
 			}
+
+            var scrolled = false;
+
+            function handleTextareaScroll() {
+                if (!scrolled) {
+                    if (iFrame) {
+                        var scrollRate = $(this).scrollTop() / this.scrollHeight;
+
+                        iFrame.contents().scrollTop(scrollRate*iFrame.contents().height());
+
+                        scrolled = true;
+                    }
+                }
+                else {
+                    scrolled = false;
+                }
+            }
+
+            function handleiFrameScroll() {
+                if (!scrolled) {
+                    var scrollRate = iFrame.contents().scrollTop() / iFrame.contents().height();
+
+                    $(textarea).scrollTop(scrollRate*textarea.scrollHeight);
+
+                    scrolled = true;
+                }
+                else {
+                    scrolled = false;
+                }
+            }
 
 			init();
 		});

--- a/django_markdown/static/django_markdown/skins/simple/style.css
+++ b/django_markdown/static/django_markdown/skins/simple/style.css
@@ -3,116 +3,128 @@
 // By Jay Salvat - http://markitup.jaysalvat.com/
 // ------------------------------------------------------------------*/
 .markItUp * {
-	margin:0px; padding:0px;
-	outline:none;
+    margin:0px; padding:0px;
+    outline:none;
 }
 .markItUp a:link,
 .markItUp a:visited {
-	color:#000;
-	text-decoration:none;
+    color:#000;
+    text-decoration:none;
 }
 .markItUp  {
-	width:700px;
-	margin:5px 0 5px 0;
+    /*width:700px;*/
+    margin:5px 0 5px 0;
+
+    width:100%;
 }
 .markItUpContainer  {
-	font:11px Verdana, Arial, Helvetica, sans-serif;
+    font:11px Verdana, Arial, Helvetica, sans-serif;
 }
 .markItUpEditor {
-	font:12px 'Courier New', Courier, monospace;
-	padding:5px;
-	width:690px;
-	height:320px;
-	clear:both; display:block;
-	line-height:18px;
-	overflow:auto;
+    font:12px 'Courier New', Courier, monospace;
+    padding:5px;
+    /*width:690px;*/
+    height:320px;
+    clear:both; display:block;
+    line-height:18px;
+    overflow:auto;
+
+    width:49%;
+    float: left;
 }
 .markItUpPreviewFrame	{
-	overflow:auto;
-	background-color:#FFF;
-	width:99.9%;
-	height:300px;
-	margin:5px 0;
+    overflow:auto;
+    background-color:#FFF;
+    /*width:99.9%;*/
+    /*height:300px;*/
+    /*margin:5px 0;*/
+
+    width: 49%;
+    height: 328px;
 }
 .markItUpFooter {
-	width:100%;
+    width:100%;
 }
 .markItUpResizeHandle {
-	overflow:hidden;
-	width:22px; height:5px;
-	margin-left:auto;
-	margin-right:auto;
-	background-image:url(images/handle.png);
-	cursor:n-resize;
+    overflow:hidden;
+    width:22px; height:5px;
+    margin-left:auto;
+    margin-right:auto;
+    background-image:url(images/handle.png);
+    cursor:n-resize;
 }
 /***************************************************************************************/
+.markItUpHeader {
+    width: 100%;
+    height: 22px;
+}
 /* first row of buttons */
 .markItUpHeader ul li	{
-	list-style:none;
-	float:left;
-	position:relative;
+    list-style:none;
+    float:left;
+    position:relative;
 }
 .markItUpHeader ul li:hover > ul{
-	display:block;
+    display:block;
 }
 .markItUpHeader ul .markItUpDropMenu {
-	background:transparent url(images/menu.png) no-repeat 115% 50%;
-	margin-right:5px;
+    background:transparent url(images/menu.png) no-repeat 115% 50%;
+    margin-right:5px;
 }
 .markItUpHeader ul .markItUpDropMenu li {
-	margin-right:0px;
+    margin-right:0px;
 }
 /* next rows of buttons */
 .markItUpHeader ul ul {
-	display:none;
-	position:absolute;
-	top:18px; left:0px;	
-	background:#FFF;
-	border:1px solid #000;
+    display:none;
+    position:absolute;
+    top:18px; left:0px;
+    background:#FFF;
+    border:1px solid #000;
 }
 .markItUpHeader ul ul li {
-	float:none;
-	border-bottom:1px solid #000;
+    float:none;
+    border-bottom:1px solid #000;
 }
 .markItUpHeader ul ul .markItUpDropMenu {
-	background:#FFF url(images/submenu.png) no-repeat 100% 50%;
+    background:#FFF url(images/submenu.png) no-repeat 100% 50%;
 }
 .markItUpHeader ul .markItUpSeparator {
-	margin:0 10px;
-	width:1px;
-	height:16px;
-	overflow:hidden;
-	background-color:#CCC;
+    margin:0 10px;
+    width:1px;
+    height:16px;
+    overflow:hidden;
+    background-color:#CCC;
 }
 .markItUpHeader ul ul .markItUpSeparator {
-	width:auto; height:1px;
-	margin:0px;
+    width:auto; height:1px;
+    margin:0px;
 }
 /* next rows of buttons */
 .markItUpHeader ul ul ul {
-	position:absolute;
-	top:-1px; left:150px; 
+    position:absolute;
+    top:-1px; left:150px;
 }
 .markItUpHeader ul ul ul li {
-	float:none;
+    float:none;
 }
 .markItUpHeader ul a {
-	display:block;
-	width:16px; height:16px;
-	text-indent:-10000px;
-	background-repeat:no-repeat;
-	padding:3px;
-	margin:0px;
+    display:block;
+    width:16px; height:16px;
+    text-indent:-10000px;
+    background-repeat:no-repeat;
+    padding:3px;
+    margin:0px;
 }
 .markItUpHeader ul ul a {
-	display:block;
-	padding-left:0px;
-	text-indent:0;
-	width:120px; 
-	padding:5px 5px 5px 25px;
-	background-position:2px 50%;
+    display:block;
+    padding-left:0px;
+    text-indent:0;
+    width:120px;
+    padding:5px 5px 5px 25px;
+    background-position:2px 50%;
 }
 .markItUpHeader ul ul a:hover  {
-	color:#FFF;
-	background-color:#000;
+    color:#FFF;
+    background-color:#000;
 }

--- a/django_markdown/templates/django_markdown/preview.html
+++ b/django_markdown/templates/django_markdown/preview.html
@@ -5,7 +5,7 @@
 <base target="_blank">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>markItUp! preview</title>
-<link rel="stylesheet" type="text/css" href="{% firstof STATIC_URL MEDIA_URL %}django_markdown/preview.css" />
+<link rel="stylesheet" type="text/css" href="{{ params.css }}" />
 </head>
 <body>
 {{ params.content|markdown }}

--- a/django_markdown/templates/django_markdown/preview.html
+++ b/django_markdown/templates/django_markdown/preview.html
@@ -2,6 +2,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
+<base target="_blank">
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <title>markItUp! preview</title>
 <link rel="stylesheet" type="text/css" href="{% firstof STATIC_URL MEDIA_URL %}django_markdown/preview.css" />

--- a/django_markdown/views.py
+++ b/django_markdown/views.py
@@ -1,7 +1,10 @@
 from django.views.generic.simple import direct_to_template
-
+from django.conf import settings
 
 def preview(request):
+    media_or_static = settings.STATIC_URL or settings.MEDIA_URL
+    css = getattr(settings, 'DJANGO_MARKDOWN_STYLE', media_or_static+'django_markdown/preview.css')
+
     return direct_to_template(
-            request, 'django_markdown/preview.html',
-            content=request.REQUEST.get('data', 'No content posted'))
+        request, 'django_markdown/preview.html',
+        content=request.REQUEST.get('data', 'No content posted'), css=css)


### PR DESCRIPTION
MarkdownWidget being displaying textarea and iframe side-by-side with auto updating scroll position.

Preview using new settings attribute DJANGO_MARKDOWN_STYLE as a path to a custom CSS. If not set, the default value is the default CSS.
