### PR TITLE
Patching use of deprecated django.utils.simplejson

### DIFF
--- a/django_markdown/widgets.py
+++ b/django_markdown/widgets.py
@@ -1,9 +1,14 @@
 from django import forms
 from django.conf import settings
 from django.core.urlresolvers import reverse
-from django.utils import simplejson
 from django.utils.safestring import mark_safe
-
+try:
+    import json as simplejson
+except ImportError:
+    try:
+        import simplejson
+    except ImportError:
+        from django.utils import simplejson
 
 class MarkdownWidget(forms.Textarea):
 


### PR DESCRIPTION
I got the following error:

```
    DeprecationWarning: django.utils.simplejson is deprecated; use json instead.
    from django.utils import simplejson
```

Patch from https://github.com/joshuakarjala/sorl-thumbnail/commit/04e019507ff9841443ae0b252aed2dc2472743ff
