### PR TITLE
Markdown has a bunch of extensions for supporting additional markdown features

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -126,7 +126,13 @@ Example: `settings.py` ::
 
     MARKDOWN_EDITOR_SKIN = 'simple'
 
-**MARKDOWN_EDITOR_SETTINGS** - holds the extra parameters set to be passed to textarea.markItUp() 
+**MARKDOWN_EDITOR_SETTINGS** - holds the extra parameters set to be passed to textarea.markItUp()
+
+**MARKDOWN_EXTENSIONS** - optional list of extensions passed to Markdown, discussed at https://pythonhosted.org/Markdown/extensions/index.html#officially-supported-extensions
+
+Example: `settings.py` ::
+
+    MARKDOWN_EXTENSIONS = ['extra']
 
 
 Changes

--- a/django_markdown/templatetags/django_markdown.py
+++ b/django_markdown/templatetags/django_markdown.py
@@ -1,6 +1,7 @@
 """ Support 'markdown' filter. """
 
 from django import template
+from django.conf import settings
 from django.utils.safestring import mark_safe
 from django.utils.encoding import force_text
 
@@ -18,7 +19,7 @@ def markdown(value):
 
     """
     return mark_safe(
-        markdown_module.markdown(force_text(value), safe_mode=False))
+        markdown_module.markdown(force_text(value), extensions=getattr(settings, 'MARKDOWN_EXTENSIONS', []), safe_mode=False))
 
 
 @register.filter(is_safe=True)
@@ -29,4 +30,4 @@ def markdown_safe(value):
 
     """
     return mark_safe(
-        markdown_module.markdown(force_text(value), safe_mode=True))
+        markdown_module.markdown(force_text(value), extensions=getattr(settings, 'MARKDOWN_EXTENSIONS', []), safe_mode=True))


### PR DESCRIPTION
...such as tables, footnotes, etc.  More here: https://pythonhosted.org/Markdown/extensions/index.html#officially-supported-extensions

I updated the templatetags to pass the extensions argument from a new setting.  Also updated the readme so folks know where to look for the available extensions.
