### PR TITLE
INIT_TEMPLATE Initialization Fix

### DIFF
--- a/django_markdown/utils.py
+++ b/django_markdown/utils.py
@@ -16,10 +16,6 @@ except ImportError:
 from . import settings
 
 
-INIT_TEMPLATE = loader.get_template(
-    settings.MARKDOWN_EDITOR_INIT_TEMPLATE)
-
-
 def markdown(value, extensions=settings.MARKDOWN_EXTENSIONS,
              extension_configs=settings.MARKDOWN_EXTENSION_CONFIGS,
              safe=False):
@@ -37,6 +33,9 @@ def markdown(value, extensions=settings.MARKDOWN_EXTENSIONS,
 
 def editor_js_initialization(selector, **extra_settings):
     """ Return script tag with initialization code. """
+
+    INIT_TEMPLATE = loader.get_template(
+        settings.MARKDOWN_EDITOR_INIT_TEMPLATE)
 
     options = dict(
         previewParserPath=reverse('django_markdown_preview'),


### PR DESCRIPTION
Hi,

I want to use django_markdown by depending on a settings variable like MARKDOWN_ENABLED boolean, so in admin.py I import its widget like that:

```
    try:
            from django_markdown.widgets import MarkdownWidget
    except ImportError:
            pass
```

However, because of admin.auto_discover, it initializes these lines `INIT_TEMPLATE = loader.get_template(settings.MARKDOWN_EDITOR_INIT_TEMPLATE)` under utils.py. If django_markdown isn't included in INSTALLED_APPS, this crushes the whole app, because it can't find django_markdown/editor_init.html.

So why not move it into `editor_js_initialization`, since it is not imported anywhere else.
