### PR TITLE
Fixing static_url issue, making package use MarkdownFields instead of Textfields.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 commit = True
-current_version = 0.8.0
+current_version = 0.8.1
 files = django_markdown/__init__.py
 tag = True
 tag_name = {new_version}

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -14,3 +14,4 @@ Contributors:
 * Sergii Iavorskyi (https://github.com/yavorskiy)
 * Tom O'onnor' (https://github.com/tomoconnor)
 * dfeinzeig (https://github.com/dfeinzeig)
+* Wellington Cordeiro (https://github.com/wldcordeiro)

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,8 @@
+2014-12-04  wldcordeiro
+	* Removed static_url setting from package settings due to collision with user setting.
+	* Modified the ModelAdmins to only override MarkdownFields since some users want normal Textfields to display normall.
+	* Version 0.8.1
+
 2014-09-25  horneds
 
 	* Remove python2.6, Django 1.4 support

--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,13 @@ Use django_markdown
     from django_markdown.admin import MarkdownModelAdmin
     admin.site.register(MyModel, MarkdownModelAdmin)
 
+#) Admin Overrides: (If you don't want to subclass package ModelAdmin's) ::
+
+    from django.contrib import admin
+
+    class YourModelAdmin(admin.ModelAdmin):
+        formfield_overrides = {MarkdownField: {'widget': AdminMarkdownWidget}}
+
 #) Flatpages: ::
 
     # in your project main urls
@@ -172,7 +179,7 @@ Contributors
 
 * klen_ (Kirill Klenov)
 
-* yavorskiy_ (Sergii Iavorskyi) 
+* yavorskiy_ (Sergii Iavorskyi)
 
 
 License

--- a/django_markdown/admin.py
+++ b/django_markdown/admin.py
@@ -4,17 +4,18 @@ from django.contrib import admin
 from django.db import models
 
 from django_markdown.widgets import AdminMarkdownWidget
+from django_markdown.models import MarkdownField
 
 
 class MarkdownModelAdmin(admin.ModelAdmin):
 
     """ Support markdown as ModelAdmin. """
 
-    formfield_overrides = {models.TextField: {'widget': AdminMarkdownWidget}}
+    formfield_overrides = {MarkdownField: {'widget': AdminMarkdownWidget}}
 
 
 class MarkdownInlineAdmin(admin.StackedInline):
 
     """ Support markdown as StackedInline. """
 
-    formfield_overrides = {models.TextField: {'widget': AdminMarkdownWidget}}
+    formfield_overrides = {MarkdownField: {'widget': AdminMarkdownWidget}}

--- a/django_markdown/settings.py
+++ b/django_markdown/settings.py
@@ -17,5 +17,4 @@ MARKDOWN_PREVIEW_TEMPLATE = getattr(settings, 'MARKDOWN_PREVIEW_TEMPLATE', 'djan
 MARKDOWN_STYLE = getattr(settings, 'MARKDOWN_STYLE', 'django_markdown/preview.css')
 MARKDOWN_PROTECT_PREVIEW = getattr(settings, 'MARKDOWN_PROTECT_PREVIEW', False)
 
-STATIC_URL = settings.STATIC_URL or settings.MEDIA_URL
 LOGIN_URL = settings.LOGIN_URL

--- a/django_markdown/templates/django_markdown/media_css.html
+++ b/django_markdown/templates/django_markdown/media_css.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load django_markdown_static %}
 
 <link rel="stylesheet" type="text/css" href="{% static CSS_SKIN %}" />
 <link rel="stylesheet" type="text/css" href="{% static CSS_SET %}" />

--- a/django_markdown/templates/django_markdown/media_js.html
+++ b/django_markdown/templates/django_markdown/media_js.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load django_markdown_static %}
 <script language="javascript" type="text/javascript" src="{% static "django_markdown/jquery.init.js" %}"></script>
 <script language="javascript" type="text/javascript" src="{% static "django_markdown/jquery.markitup.js" %}"></script>
 <script language="javascript" type="text/javascript" src="{% static JS_SET %}"></script>

--- a/django_markdown/templatetags/django_markdown_static.py
+++ b/django_markdown/templatetags/django_markdown_static.py
@@ -1,0 +1,17 @@
+from django.apps import apps
+from django.template import Library
+
+register = Library()
+
+_static = None
+
+
+@register.simple_tag
+def static(path):
+    global _static
+    if _static is None:
+        if apps.is_installed('django.contrib.staticfiles'):
+            from django.contrib.staticfiles.templatetags.staticfiles import static as _static
+        else:
+            from django.templatetags.static import static as _static
+    return _static(path)

--- a/example.py
+++ b/example.py
@@ -36,8 +36,10 @@ if not settings.configured:
 # ------
 from django.db import models
 
+from django_markdown.models import MarkdownField
+
 class Test(models.Model):
-    content = models.TextField()
+    content = MarkdownField()
 
     class Meta:
         app_label = 'test'


### PR DESCRIPTION
Fixing issue in #39 and some other changes.

Fixing issue with static_url setting overriding the user's since it relied on an or that would eval

to the user's media_url. Also modified the ModelAdmins to only override the MarkdownFields instead of
Textfields so that Textfields display normally unless users specify it as MarkdownField's.
