### PR TITLE
django_markdown_static is not a valid tag library

### DIFF
--- a/django_markdown/templatetags/django_markdown_static.py
+++ b/django_markdown/templatetags/django_markdown_static.py
@@ -1,5 +1,5 @@
-from django.apps import apps
 from django.template import Library
+from django.conf import settings
 
 register = Library()
 
@@ -10,7 +10,7 @@ _static = None
 def static(path):
     global _static
     if _static is None:
-        if apps.is_installed('django.contrib.staticfiles'):
+        if 'django.contrib.staticfiles' in settings.INSTALLED_APPS:
             from django.contrib.staticfiles.templatetags.staticfiles import static as _static
         else:
             from django.templatetags.static import static as _static

--- a/django_markdown/templatetags/django_markdown_static.py
+++ b/django_markdown/templatetags/django_markdown_static.py
@@ -6,11 +6,24 @@ register = Library()
 _static = None
 
 
+def _is_installed(app):
+    """Workaround for checking whether app is installed that is compatable with
+    django 1.7 approach as well as providing backward compatability with
+    versions <1.7
+    """
+    try:
+        from django.apps import apps
+    except ImportError:
+        from django.conf import settings
+        return app in settings.INSTALLED_APPS
+    else:
+        return apps.is_installed(app)
+
 @register.simple_tag
 def static(path):
     global _static
     if _static is None:
-        if 'django.contrib.staticfiles' in settings.INSTALLED_APPS:
+        if _is_installed('django.contrib.staticfiles'):
             from django.contrib.staticfiles.templatetags.staticfiles import static as _static
         else:
             from django.templatetags.static import static as _static


### PR DESCRIPTION
I was just experimenting with your package for the first time—looks awesome!—and I ran into some trouble when I was trying to use the templatetags to render the javascript editors. Below is a screenshot of the error I was receiving. It looks like django 1.6 is having problems with [this line](https://github.com/klen/django_markdown/blob/develop/django_markdown/templatetags/django_markdown_static.py#L1). Any ideas for how to fix?

![screen shot 2014-12-10 at 2 53 14 pm](https://cloud.githubusercontent.com/assets/255672/5384094/74b2ae7e-807c-11e4-80f5-da800e1b6ae4.png)
