### PR TITLE
Fixes the size of Markdown fields in the admin, plus one other minor error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ t: clean $(VIRTUALENV)/bin/py.test
 	@$(VIRTUALENV)/bin/py.test
 
 $(CURDIR)/example/db.sqlite3: $(VIRTUALENV)
-	$(VIRTUALENV)/bin/python example/manage.py syncdb --noinput
+	$(VIRTUALENV)/bin/python example/manage.py migrate --noinput
 
 .PHONY: run
 run: $(CURDIR)/example/db.sqlite3

--- a/django_markdown/fields.py
+++ b/django_markdown/fields.py
@@ -1,10 +1,5 @@
 from django import forms
-from .widgets import MarkdownWidget
 
 
 class MarkdownFormField(forms.CharField):
-    def __init__(self, *args, **kwargs):
-        # Django admin overrides the 'widget' value so this seems the only way
-        # to scupper it!
-        super(MarkdownFormField, self).__init__(*args, **kwargs)
-        self.widget = MarkdownWidget()
+    pass

--- a/django_markdown/models.py
+++ b/django_markdown/models.py
@@ -1,10 +1,9 @@
 from django.db import models
-from .fields import MarkdownFormField
 from .widgets import MarkdownWidget
 
 
 class MarkdownField(models.TextField):
     def formfield(self, **kwargs):
-        defaults = {'form_class': MarkdownFormField}
+        defaults = {'widget': MarkdownWidget}
         defaults.update(kwargs)
         return super(MarkdownField, self).formfield(**defaults)

--- a/django_markdown/static/django_markdown/jquery.init.js
+++ b/django_markdown/static/django_markdown/jquery.init.js
@@ -35,4 +35,12 @@ jQuery = jQuery || django.jQuery;
         }
     });
 
- })(jQuery);
+    $(document).ready(function() {
+        var extra_settings = (extra_markitup_settings === undefined) ? {} : extra_markitup_settings;
+
+        $("[data-widget='markItUpEditor']")
+            .markItUp(mySettings, extra_settings)
+            .removeData('data-widget');
+    });
+
+})(jQuery);

--- a/django_markdown/templates/django_markdown/editor_init.html
+++ b/django_markdown/templates/django_markdown/editor_init.html
@@ -1,4 +1,4 @@
 <script type="text/javascript">
-var extra_markitup_settings = {{ extra_settings|default:"{}" }};
+var extra_markitup_settings = {{ extra_settings|default:"{}"|safe }};
 </script>
 

--- a/django_markdown/templates/django_markdown/editor_init.html
+++ b/django_markdown/templates/django_markdown/editor_init.html
@@ -1,12 +1,4 @@
 <script type="text/javascript">
-(function($) {
-    $(document).ready(function() {
-        $("{{ selector }}").each(function (k, el) {
-            var el = $(el);
-            if(!el.hasClass("markItUpEditor")) el.markItUp(
-                mySettings, {{ extra_settings|default:"{}" }});
-        });
-    });
-})(jQuery);
+var extra_markitup_settings = {{ extra_settings|default:"{}" }};
 </script>
 

--- a/django_markdown/urls.py
+++ b/django_markdown/urls.py
@@ -1,8 +1,9 @@
 """ Define preview URL. """
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import preview
 
-urlpatterns = patterns(
-    '', url('preview/$', preview, name='django_markdown_preview'))
+urlpatterns = [
+    url('preview/$', preview, name='django_markdown_preview')
+]

--- a/django_markdown/views.py
+++ b/django_markdown/views.py
@@ -19,6 +19,6 @@ def preview(request):
 
     return render(
         request, settings.MARKDOWN_PREVIEW_TEMPLATE, dict(
-            content=request.REQUEST.get('data', 'No content posted'),
+            content=request.POST.get('data', 'No content posted'),
             css=settings.MARKDOWN_STYLE
         ))

--- a/django_markdown/widgets.py
+++ b/django_markdown/widgets.py
@@ -24,17 +24,19 @@ class MarkdownWidget(forms.Textarea):
 
     """
 
-    def __init__(self, attrs=None):
-        super(MarkdownWidget, self).__init__(attrs)
-
     def render(self, name, value, attrs=None):
         """ Render widget.
 
         :returns: A rendered HTML
 
         """
-        html = super(MarkdownWidget, self).render(name, value, attrs)
-        attrs = self.build_attrs(attrs)
+
+        final_attrs = {'data-widget': 'markItUpEditor'}
+        if attrs is not None:
+            final_attrs.update(attrs)
+
+        html = super(MarkdownWidget, self).render(name, value, final_attrs)
+        final_attrs = self.build_attrs(final_attrs)
         html += editor_js_initialization("#%s" % attrs['id'])
         return mark_safe(html)
 


### PR DESCRIPTION
The main issue I fixed is that in the admin the Markdown textareas were very narrow, and there was no way to fix it from an application (without monkey patching). The issue was due to the fact that `MarkdownField` explicitly sets its `form_class` to `MarkdownFormField`, which clobbers any attempt to override the widget. Based on the comment in the source, this was apparently done in an attempt to prevent `django.contrib.admin.ModelAdmin` from overriding the default widget. The correct way to do that is what has already been implemented in this project – using `formfield_overrides` in a subclass of `ModelAdmin`. So, since the problem is already solved in the correct way, I'm pretty sure I'm more or less just reverting it to an earlier behavior.

The other issue this pull request fixes is an issue when using a Markdown field on the frontend results in a JS error when JS files are included at the bottom of the body (which is a best practice). The closures in `editor_init.html` explicitly reference the variable `jQuery` in the global scope, but since jquery isn't included until later, the variable doesn't yet exist. My fix actually simplifies the code quite a bit by identifying the markdown elements using a "widget" custom data attribute, then running `markItUp` using a selector in `jquery.init.js`. Since we still need `extra_settings` I changed it to simply set it as a global variable named `extra_markitup_settings`, since it'll have the same value for each field.

I also removed the `__init__` method from `MarkdownWidget`, since all it wasn't actually doing anything that wouldn't happen if it didn't exist.
