### PR TITLE
Use staticfiles_storage to generate static files urls for widgets.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -17,3 +17,4 @@ Contributors:
 * Tom O'onnor' (https://github.com/tomoconnor)
 * Wellington Cordeiro (https://github.com/wldcordeiro)
 * dfeinzeig (https://github.com/dfeinzeig)
+* Nathan Gaberel (https://github.com/n6g7)

--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,9 @@
+2015-10-04 Nathan Gaberel
+
+	* Use staticfiles_storage to generate static files urls for widgets.
+
 2014-12-08  wldcordeiro
+
 	* Fixing the static loading issue properly.
 	* version 0.8.2
 

--- a/django_markdown/views.py
+++ b/django_markdown/views.py
@@ -1,5 +1,4 @@
 """ Supports preview. """
-from django.core.files.storage import default_storage
 from django.shortcuts import render
 
 from . import settings

--- a/django_markdown/widgets.py
+++ b/django_markdown/widgets.py
@@ -3,7 +3,7 @@ import os
 
 from django import forms
 from django.contrib.admin.widgets import AdminTextareaWidget
-from django.core.files.storage import default_storage
+from django.contrib.staticfiles.storage import staticfiles_storage
 from django.utils.safestring import mark_safe
 
 from . import settings
@@ -41,17 +41,16 @@ class MarkdownWidget(forms.Textarea):
     class Media:
         css = {
             'screen': (
-                os.path.join('django_markdown', 'skins', settings.MARKDOWN_EDITOR_SKIN, 'style.css'),
-                os.path.join(settings.MARKDOWN_SET_PATH, settings.MARKDOWN_SET_NAME, 'style.css')
+                staticfiles_storage.url(os.path.join('django_markdown', 'skins', settings.MARKDOWN_EDITOR_SKIN, 'style.css')),
+                staticfiles_storage.url(os.path.join(settings.MARKDOWN_SET_PATH, settings.MARKDOWN_SET_NAME, 'style.css'))
             )
         }
 
         js = (
-            os.path.join('django_markdown', 'jquery.init.js'),
-            os.path.join('django_markdown', 'jquery.markitup.js'),
-            os.path.join(settings.MARKDOWN_SET_PATH, settings.MARKDOWN_SET_NAME, 'set.js')
+            staticfiles_storage.url(os.path.join('django_markdown', 'jquery.init.js')),
+            staticfiles_storage.url(os.path.join('django_markdown', 'jquery.markitup.js')),
+            staticfiles_storage.url(os.path.join(settings.MARKDOWN_SET_PATH, settings.MARKDOWN_SET_NAME, 'set.js'))
         )
-
 
 class AdminMarkdownWidget(MarkdownWidget, AdminTextareaWidget):
 


### PR DESCRIPTION
Hi,

Currently the urls for the widgets assets aren't processed by the project's defined static file storage (`STATICFILES_STORAGE` in the settings) and so, when using a custom static file storage (like [django-s3-storage](https://github.com/etianen/django-s3-storage)), the generated urls results in 404.

I sent these file paths through `django.contrib.staticfiles.storage.staticfiles_storage.url` to address this issue.

This fixed a bug I had where the assets for the admin widget would point to `/admin/app/model/id/django_markdown/...` instead of `https://s3-eu-west-1.amazonaws.com/bucket/static/django_markdown/...` (I use S3 storage) and thus the widget would render as a simple textarea.
