### PR TITLE
Remove depreciated 'django.conf.urls.patterns'

### DIFF
--- a/django_markdown/urls.py
+++ b/django_markdown/urls.py
@@ -1,8 +1,8 @@
 """ Define preview URL. """
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import preview
 
-urlpatterns = patterns(
-    '', url('preview/$', preview, name='django_markdown_preview'))
+urlpatterns = [
+    url('preview/$', preview, name='django_markdown_preview')]

--- a/django_markdown/urls.py
+++ b/django_markdown/urls.py
@@ -5,4 +5,4 @@ from django.conf.urls import url
 from .views import preview
 
 urlpatterns = [
-    url('preview/$', preview, name='django_markdown_preview')]
+    url(r'^preview/$', preview, name='django_markdown_preview')]

--- a/example/project/urls.py
+++ b/example/project/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 from django.contrib import admin
 admin.autodiscover()
@@ -6,9 +6,9 @@ admin.autodiscover()
 from django_markdown import flatpages
 flatpages.register()
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^markdown/', include('django_markdown.urls')),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^pages/', include('django.contrib.flatpages.urls')),
     url(r'', include('project.md.urls')),
-)
+]

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,5 @@
-from django.conf.urls import include, patterns
+from django.conf.urls import include, url
 
-urlpatterns = patterns(
-    '',
-    (r'^markdown/', include('django_markdown.urls')),
-)
+urlpatterns = [
+    url(r'^markdown/', include('django_markdown.urls')),
+]


### PR DESCRIPTION
Fixes `RemovedInDjango110Warning` in `urls.py` for Django >= 1.8

If support for older versions is still needed, I can add version checks.
