### PR TITLE
Update views.py

### DIFF
--- a/django_markdown/views.py
+++ b/django_markdown/views.py
@@ -19,6 +19,6 @@ def preview(request):
 
     return render(
         request, settings.MARKDOWN_PREVIEW_TEMPLATE, dict(
-            content=request.REQUEST.get('data', 'No content posted'),
+            content=request.POST.get('data', 'No content posted'),
             css=settings.MARKDOWN_STYLE
         ))


### PR DESCRIPTION
django_markdown failed to show preview in django 1.9. Since request.REQUEST was deprecated in Django 1.7 and removed from Django 1.9, the new code read data from request.POST instead.
