### PR TITLE
Adding check for request.POST (django >=1.9) cf. request.REQUEST (django <= 1.8)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,3 @@
 [run]
 source=django_markdown
 
-[report]
-include=django_markdown

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
-[report]
-source=django_markdown
-
 [run]
 source=django_markdown
+
+[report]
+include=django_markdown

--- a/django_markdown/views.py
+++ b/django_markdown/views.py
@@ -17,8 +17,13 @@ def preview(request):
             from django.contrib.auth.views import redirect_to_login
             return redirect_to_login(request.get_full_path())
 
+    if request.POST:
+        content = request.POST.get('data', 'No content posted')
+    else:
+        content = request.REQUEST.get('data', 'No content posted')
+
     return render(
         request, settings.MARKDOWN_PREVIEW_TEMPLATE, dict(
-            content=request.REQUEST.get('data', 'No content posted'),
+            content=content,
             css=settings.MARKDOWN_STYLE
         ))


### PR DESCRIPTION
Here's a little conditional that will handle older django versions and recent 1.9 and newer when calling preview on a markdown field.
