### PR TITLE
Updated urls.py and utils.py to get rid of deprecation warnings

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,2 @@
-[report]
-source=django_markdown
-
 [run]
 source=django_markdown

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,12 @@ language: python
 
 python:
 - "2.7"
+- "3.4"
 
 env:
-- TOXENV=py27-d16
-- TOXENV=py27-d17
-- TOXENV=py34-d17
+- TOXENV=d16
+- TOXENV=d17
 - TOXENV=cov
-
-branches:
-    only:
-    - master
-    - develop
 
 install: pip install --quiet --use-mirrors tox
 

--- a/django_markdown/urls.py
+++ b/django_markdown/urls.py
@@ -1,8 +1,9 @@
 """ Define preview URL. """
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import preview
 
-urlpatterns = patterns(
-    '', url('preview/$', preview, name='django_markdown_preview'))
+urlpatterns = [
+    url(r'^preview/$', preview, name='django_markdown_preview')
+]

--- a/django_markdown/utils.py
+++ b/django_markdown/utils.py
@@ -3,7 +3,7 @@ from django.core.urlresolvers import reverse
 import markdown as markdown_module
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
-from django.template import loader, Context
+from django.template import loader
 
 try:
     import json as simplejson

--- a/django_markdown/utils.py
+++ b/django_markdown/utils.py
@@ -41,7 +41,6 @@ def editor_js_initialization(selector, **extra_settings):
         previewParserPath=reverse('django_markdown_preview'),
         **settings.MARKDOWN_EDITOR_SETTINGS)
     options.update(extra_settings)
-    ctx = Context(dict(
-        selector=selector, extra_settings=simplejson.dumps(options)),
-        autoescape=False)
+    ctx = dict(selector=selector,
+               extra_settings=mark_safe(simplejson.dumps(options)))
     return INIT_TEMPLATE.render(ctx)

--- a/django_markdown/views.py
+++ b/django_markdown/views.py
@@ -17,8 +17,14 @@ def preview(request):
             from django.contrib.auth.views import redirect_to_login
             return redirect_to_login(request.get_full_path())
 
+    # https://github.com/klen/django_markdown/pull/60
+    if request.POST:
+        content = request.POST.get('data', 'No content posted.')
+    else:
+        content = request.REQUEST.get('data', 'No content posted.')
+
     return render(
         request, settings.MARKDOWN_PREVIEW_TEMPLATE, dict(
-            content=request.REQUEST.get('data', 'No content posted'),
+            content=content,
             css=settings.MARKDOWN_STYLE
         ))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27-d16,py27-d17,py34-d17,cov
+envlist=d16,d17,cov
 
 [pylama]
 skip=example/*
@@ -26,20 +26,14 @@ commands=py.test
 deps =
     pytest
 
-[testenv:py27-d16]
+[testenv:d16]
 basepython = python2.7
 deps =
     django==1.6.7
     {[testenv]deps}
 
-[testenv:py27-d17]
+[testenv:d17]
 basepython = python2.7
-deps =
-    django==1.7
-    {[testenv]deps}
-
-[testenv:py34-d17]
-basepython = python3.4
 deps =
     django==1.7
     {[testenv]deps}


### PR DESCRIPTION
Update to get rid of deprecation warnings. Stopped using patterns() in urls.py. Changed `ctx` in utils.py to a dictionary rather than a context. Used `mark_safe` on the `extra_settings` parameter to prevent escaping. 

Added conditional from #60 to handle different django versions when calling markdown preview.
