### PR TITLE
added django 1.10  compatibility 

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,2 @@
-[report]
-source=django_markdown
-
 [run]
 source=django_markdown

--- a/django_markdown/admin.py
+++ b/django_markdown/admin.py
@@ -1,7 +1,6 @@
 """ Support Django admin. """
 
 from django.contrib import admin
-from django.db import models
 
 from django_markdown.widgets import AdminMarkdownWidget
 from django_markdown.models import MarkdownField

--- a/django_markdown/models.py
+++ b/django_markdown/models.py
@@ -1,6 +1,5 @@
 from django.db import models
 from .fields import MarkdownFormField
-from .widgets import MarkdownWidget
 
 
 class MarkdownField(models.TextField):

--- a/django_markdown/pypandoc.py
+++ b/django_markdown/pypandoc.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import with_statement
+import subprocess
+import os
 
 __author__ = 'Juho Vepsäläinen'
 __version__ = '0.8.2'
 __license__ = 'MIT'
 __all__ = ['convert', 'get_pandoc_formats']
-
-import subprocess
-import os
 
 
 def convert(source, to, format=None, extra_args=(), encoding='utf-8'):

--- a/django_markdown/templates/django_markdown/editor_init.html
+++ b/django_markdown/templates/django_markdown/editor_init.html
@@ -4,9 +4,8 @@
         $("{{ selector }}").each(function (k, el) {
             var el = $(el);
             if(!el.hasClass("markItUpEditor")) el.markItUp(
-                mySettings, {{ extra_settings|default:"{}" }});
+                mySettings, {{ extra_settings|safe|default:"{}" }});
         });
     });
 })(jQuery);
 </script>
-

--- a/django_markdown/templatetags/django_markdown.py
+++ b/django_markdown/templatetags/django_markdown.py
@@ -3,8 +3,9 @@ import posixpath
 
 from django import template
 from django.core.urlresolvers import reverse
+from django.utils.safestring import mark_safe
 
-from ..utils import markdown as _markdown, settings, simplejson, mark_safe
+from ..utils import markdown as _markdown, settings, simplejson
 
 
 register = template.Library()

--- a/django_markdown/tests.py
+++ b/django_markdown/tests.py
@@ -1,11 +1,8 @@
 from django.test import TestCase
+from django.contrib.auth.models import User
+
 from django_markdown.utils import markdown as markdown_util
-
-from django_markdown.templatetags.django_markdown import (
-    markdown as markdown_tag
-)
-
-from django.contrib.auth import models
+from django_markdown.templatetags.django_markdown import markdown as markdown_tag
 
 
 class DjangoMarkdownTagsTest(TestCase):
@@ -52,8 +49,6 @@ class DjangoMarkdownViewsTest(TestCase):
 
     def test_preview_post_markdown_request(self):
 
-        data = {'data': "# header \n *test*"}
-
         response = self.client.post('/markdown/preview/', data=self.data)
 
         self.assertEqual(response.status_code, 200)
@@ -76,7 +71,7 @@ class DjangoMarkdownViewsTest(TestCase):
         username = 'test'
         password = 'test',
 
-        user = models.User.objects.create(
+        User.objects.create(
             username=username,
             password=password,
             is_staff=True

--- a/django_markdown/tests.py
+++ b/django_markdown/tests.py
@@ -45,7 +45,7 @@ class DjangoMarkdownViewsTest(TestCase):
 
     def test_preview_get_markdown_request(self):
 
-        response = self.client.get('/markdown/preview/', data=self.data)
+        response = self.client.post('/markdown/preview/', data=self.data)
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, '<h1>header</h1>')
@@ -84,7 +84,7 @@ class DjangoMarkdownViewsTest(TestCase):
 
         self.client.login(username=username, password=password)
 
-        response = self.client.get('/markdown/preview/', data=self.data)
+        response = self.client.post('/markdown/preview/', data=self.data)
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, '<h1>header</h1>')

--- a/django_markdown/tests.py
+++ b/django_markdown/tests.py
@@ -1,8 +1,11 @@
-from django.test import TestCase
+from django import forms
 from django.contrib.auth.models import User
+from django.template import Context, Template
+from django.test import TestCase
 
 from django_markdown.utils import markdown as markdown_util
 from django_markdown.templatetags.django_markdown import markdown as markdown_tag
+from django_markdown.widgets import MarkdownWidget
 
 
 class DjangoMarkdownTagsTest(TestCase):
@@ -83,3 +86,18 @@ class DjangoMarkdownViewsTest(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, '<h1>header</h1>')
+
+
+class DjangoMarkdownWidgetTest(TestCase):
+
+    def test_markdown_widget(self):
+        """test MarkdownWidget.render"""
+
+        form = forms.Form()
+        form.fields['test_field'] = forms.CharField(label='test', widget=MarkdownWidget)
+
+        template = Template('{% load django_markdown %}<html>{{ form }}</html>')
+        context = Context({'form': form})
+        html = template.render(context)
+
+        self.assertIn('"previewParserPath": "/markdown/preview/"', html)

--- a/django_markdown/urls.py
+++ b/django_markdown/urls.py
@@ -1,8 +1,9 @@
 """ Define preview URL. """
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import preview
 
-urlpatterns = patterns(
-    '', url('preview/$', preview, name='django_markdown_preview'))
+urlpatterns = [
+    url('preview/$', preview, name='django_markdown_preview')
+]

--- a/django_markdown/urls.py
+++ b/django_markdown/urls.py
@@ -1,9 +1,18 @@
 """ Define preview URL. """
 
+from django import VERSION
 from django.conf.urls import url
 
 from .views import preview
 
-urlpatterns = [
-    url('preview/$', preview, name='django_markdown_preview')
-]
+
+if VERSION >= (1, 8):
+    urlpatterns = [
+        url('preview/$', preview, name='django_markdown_preview')
+    ]
+else:
+    # django <= 1.7 compatibility
+    from django.conf.urls import patterns
+    urlpatterns = patterns(
+        '', url('preview/$', preview, name='django_markdown_preview')
+    )

--- a/django_markdown/utils.py
+++ b/django_markdown/utils.py
@@ -1,9 +1,12 @@
 """ Markdown utils. """
-from django.core.urlresolvers import reverse
 import markdown as markdown_module
+
+from django.core.urlresolvers import reverse
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 from django.template import loader, Context
+
+from . import settings
 
 try:
     import json as simplejson
@@ -12,8 +15,6 @@ except ImportError:
         import simplejson
     except ImportError:
         from django.utils import simplejson
-
-from . import settings
 
 
 def markdown(value, extensions=settings.MARKDOWN_EXTENSIONS,

--- a/django_markdown/utils.py
+++ b/django_markdown/utils.py
@@ -2,9 +2,9 @@
 import markdown as markdown_module
 
 from django.core.urlresolvers import reverse
+from django.template import loader, Context
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
-from django.template import loader, Context
 
 from . import settings
 

--- a/django_markdown/views.py
+++ b/django_markdown/views.py
@@ -1,5 +1,4 @@
 """ Supports preview. """
-from django.core.files.storage import default_storage
 from django.shortcuts import render
 
 from . import settings
@@ -19,6 +18,6 @@ def preview(request):
 
     return render(
         request, settings.MARKDOWN_PREVIEW_TEMPLATE, dict(
-            content=request.REQUEST.get('data', 'No content posted'),
+            content=request.POST.get('data', 'No content posted'),
             css=settings.MARKDOWN_STYLE
         ))

--- a/django_markdown/widgets.py
+++ b/django_markdown/widgets.py
@@ -3,7 +3,6 @@ import os
 
 from django import forms
 from django.contrib.admin.widgets import AdminTextareaWidget
-from django.core.files.storage import default_storage
 from django.utils.safestring import mark_safe
 
 from . import settings

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,16 +1,18 @@
 import os
 
+from django import VERSION
+from django.core.management import call_command
+
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'tests.settings')
 
-from django import VERSION
 
 if VERSION >= (1, 7):
     from django.conf import settings
     from django.apps import apps
 
     apps.populate(settings.INSTALLED_APPS)
+    call_command('migrate', interactive=False)
+else:
+    call_command('syncdb', interactive=False)
 
-from django.core.management import call_command
-call_command('syncdb', interactive=False)
-
-from django_markdown.tests import * # noqa
+from django_markdown.tests import *  # noqa

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -38,3 +38,19 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
 )
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+
+    },
+]

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,6 +1,14 @@
-from django.conf.urls import include, patterns
+from django import VERSION
+from django.conf.urls import include, url
 
-urlpatterns = patterns(
-    '',
-    (r'^markdown/', include('django_markdown.urls')),
-)
+if VERSION >= (1, 8):
+    urlpatterns  = [
+        url(r'^markdown/', include('django_markdown.urls')),
+    ]
+else:
+    # django <= 1.7.*
+    from django.conf.urls import patterns
+    urlpatterns = patterns(
+        '',
+        (r'^markdown/', include('django_markdown.urls')),
+    )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27-d16,py27-d17,py34-d17,cov
+envlist=py27-d16,py27-d17,py34-d17,py34-d110,cov
 
 [pylama]
 skip=example/*
@@ -44,10 +44,17 @@ deps =
     django==1.7
     {[testenv]deps}
 
+[testenv:py34-d110]
+basepython = python3.4
+deps =
+    django==1.10b1
+    {[testenv]deps}
+
+
 [testenv:cov]
 deps =
-    coverage
-    django==1.7
+    coverage==4.1
+    django==1.9
     {[testenv]deps}
 
 commands =


### PR DESCRIPTION
Changes:
- removed **request.REQUEST** (replaced with **request.POST**)
- use list of urls instead of 'patterns' in urls.py ( for Django >= 1.8).
- 'django.conf.urls.patterns()' will be removed in Django 1.10
