### PR TITLE
urls.py updated to work with django 1.8, 1.9, 1.10 and 1.11

### DIFF
--- a/django_markdown/urls.py
+++ b/django_markdown/urls.py
@@ -1,8 +1,9 @@
 """ Define preview URL. """
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import preview
 
-urlpatterns = patterns(
-    '', url('preview/$', preview, name='django_markdown_preview'))
+urlpatterns = [
+    url('preview/$', preview, name='django_markdown_preview'),
+]


### PR DESCRIPTION
Hey
It isn't working with latest django version 1.8, 1.9, 1.10 and 1.11
I have changed it to work with them.
Create a new version of this package with this urls.py so that this can be used with latest django version.