### PR TITLE
Django 2.0

### DIFF
--- a/django_markdown/templatetags/django_markdown.py
+++ b/django_markdown/templatetags/django_markdown.py
@@ -2,7 +2,7 @@
 import posixpath
 
 from django import template
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from ..utils import markdown as _markdown, settings, simplejson, mark_safe
 

--- a/django_markdown/templatetags/django_markdown.py
+++ b/django_markdown/templatetags/django_markdown.py
@@ -2,7 +2,11 @@
 import posixpath
 
 from django import template
-from django.urls import reverse
+
+try:  # django <= 1.6
+    from django.core.urlresolvers import reverse
+except ImportError:  # from django 1.7 to django 2.0 (and more)
+    from django.urls import reverse
 
 from ..utils import markdown as _markdown, settings, simplejson, mark_safe
 

--- a/django_markdown/utils.py
+++ b/django_markdown/utils.py
@@ -1,5 +1,5 @@
 """ Markdown utils. """
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 import markdown as markdown_module
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe

--- a/django_markdown/utils.py
+++ b/django_markdown/utils.py
@@ -1,5 +1,9 @@
 """ Markdown utils. """
-from django.urls import reverse
+try:  # django <= 1.6
+    from django.core.urlresolvers import reverse
+except ImportError:  # from django 1.7 to django 2.0 (and more)
+    from django.urls import reverse
+
 import markdown as markdown_module
 from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe


### PR DESCRIPTION
Hello there,

Django 2.0 has just been released and the `django.core.urlresolvers` submodule has been replaced by `django.urls`. This is a breaking change and we were warned about it since Django 1.7.

The following PR submit snippets that try to import urlresolvers first (for backward compatibility before Django 2.0) then, if it fails, imports `django.urls` for compatibility with new Django versions.